### PR TITLE
Add redirection for organization profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# software-gardening.github.io
+# Software Gardening organization GitHub Pages configuration
+
 Base Software Gardening GitHub Pages configuration.
+
+## Development
+
+You may place HTML content within the `/docs` folder, which is then rendered on merge to `main`.
+We adapt work here from [the documentation found in this Gist](https://gist.github.com/domenic/1f286d415559b56d725bee51a62c24a7).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; URL=https://github.com/software-gardening">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://github.com/software-gardening">
+    <title>Redirecting to https://github.com/software-gardening</title>
+</head>
+<body>
+    Redirecting to <a href="https://github.com/software-gardening">https://github.com/software-gardening</a>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a simple redirection for https://software-gardening.github.io --to--> https://github.com/software-gardening . This is mostly for potential aesthetic and ease of sharing the organization location long-term.